### PR TITLE
Update javascript_refresh.inc.php

### DIFF
--- a/templates/javascript_refresh.inc.php
+++ b/templates/javascript_refresh.inc.php
@@ -26,11 +26,13 @@
 // Set refresh interval (in seconds)
 var refreshInterval=<?php echo $refresh_limit ?>;
 
-function refresh()
-{
+function refresh() {
     <?php echo Ajax::action($ajax_url, ''); ?>;
 }
 $(document).ready(function() {
-window.setInterval(function(){refresh();}, refreshInterval * 1000);
+    clearInterval(window.reloaditv);
+    window.reloaditv = setInterval(function(){
+        refresh();
+    }, refreshInterval * 1000);
 });
 </script>


### PR DESCRIPTION
Something that bugged me since ages was that every time you refresh the page or navigate, a new "refresh" interval was spawned through Javascript. This lead to many intervals running at the same time or firing shorter than set in the config.